### PR TITLE
Add a basic update checking function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ AppPackages/
 #####
 
 config.json
+manifest.json

--- a/PLRPC.Root/Program.cs
+++ b/PLRPC.Root/Program.cs
@@ -25,6 +25,10 @@ public static class Program
             Logging.Message.New(1, $"{updateResult.TagName}: {updateResult.Url}");
             Logging.Message.New(1, $"***************************************");
         }
+        else
+        {
+            Logging.Message.New(1, $"There are no new updates available.");
+        }
 
         if (args.Length > 0)
         {

--- a/PLRPC.Root/Program.cs
+++ b/PLRPC.Root/Program.cs
@@ -16,6 +16,16 @@ public static class Program
 
     public static async Task Main(string[] args)
     {
+
+        Updater.Release? updateResult = await Updater.Updater.CheckUpdate();
+        if (updateResult != null)
+        {
+            Logging.Message.New(1, $"***************************************");
+            Logging.Message.New(1, $"A new version of PLRPC is available!");
+            Logging.Message.New(1, $"{updateResult.TagName}: {updateResult.Url}");
+            Logging.Message.New(1, $"***************************************");
+        }
+
         if (args.Length > 0)
         {
             if (args[0] == "--config")

--- a/PLRPC.Updater/Entities/Manifest.cs
+++ b/PLRPC.Updater/Entities/Manifest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace LBPUnion.PLRPC.Updater;
+
+public class Manifest
+{
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; set; } = null!;
+}

--- a/PLRPC.Updater/Entities/Release.cs
+++ b/PLRPC.Updater/Entities/Release.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace LBPUnion.PLRPC.Updater;
+
+public class Release
+{
+    [JsonPropertyName("html_url")]
+    public string Url { get; set; } = null!;
+
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; set; } = null!;
+}

--- a/PLRPC.Updater/Updater.cs
+++ b/PLRPC.Updater/Updater.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+
+namespace LBPUnion.PLRPC.Updater;
+
+public static class Updater
+{
+    public static HttpClient UpdaterHttpClient = null!;
+
+    public static async Task<Release?> CheckUpdate()
+    {
+        Release? releaseObject = null;
+        Manifest? programObject = null;
+
+        UpdaterHttpClient = new HttpClient();
+        UpdaterHttpClient.DefaultRequestHeaders.UserAgent.ParseAdd("PLRPC-Http-Updater/1.0");
+
+        if (!File.Exists(@"./manifest.json"))
+        {
+            Logging.Message.New(2, "No manifest file exists, creating a base manifest.");
+            Logging.Message.New(2, "Please restart the program to check for updates.");
+            GenerateManifest();
+            return null;
+        }
+
+        string releaseManifest = await UpdaterHttpClient.GetStringAsync("https://api.github.com/repos/LBPUnion/PLRPC/releases/latest");
+        string programManifest = File.ReadAllText(@"./manifest.json");
+
+        releaseObject = (Release?)
+                JsonSerializer.Deserialize(releaseManifest, typeof(Release));
+        programObject = (Manifest?)
+                JsonSerializer.Deserialize(programManifest, typeof(Manifest));
+
+        if (releaseObject == null)
+            return null;
+        if (programObject == null)
+            return null;
+
+        if (releaseObject.TagName == programObject.TagName)
+            return null;
+
+        return releaseObject;
+    }
+
+    public static async void GenerateManifest()
+    {
+        UpdaterHttpClient = new HttpClient();
+        UpdaterHttpClient.DefaultRequestHeaders.UserAgent.ParseAdd("PLRPC-Http-Updater/1.0");
+
+        string currentManifest = await UpdaterHttpClient.GetStringAsync("https://api.github.com/repos/LBPUnion/PLRPC/releases/latest");
+
+        Release? currentRelease = (Release?)
+                JsonSerializer.Deserialize(currentManifest, typeof(Release));
+
+        if (currentRelease == null)
+            return;
+
+        Manifest? BaseManifest = new()
+        {
+            TagName = currentRelease.TagName
+        };
+        File.WriteAllText(@"./manifest.json", JsonSerializer.Serialize(BaseManifest, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/PLRPC.Updater/Updater.cs
+++ b/PLRPC.Updater/Updater.cs
@@ -16,10 +16,8 @@ public static class Updater
 
         if (!File.Exists(@"./manifest.json"))
         {
-            Logging.Message.New(2, "No manifest file exists, creating a base manifest.");
-            Logging.Message.New(2, "Please restart the program to check for updates.");
+            Logging.Message.New(2, "No update manifest file exists, creating a base manifest.");
             GenerateManifest();
-            return null;
         }
 
         string releaseManifest = await UpdaterHttpClient.GetStringAsync("https://api.github.com/repos/LBPUnion/PLRPC/releases/latest");


### PR DESCRIPTION
This PR adds basic update checking functionality, which queries the GitHub API on start to detect if a new update is available. If there is one, a prompt will be printed in the log with the new version tag and a link to install it.