### PR TITLE
Add permission level display, do not display RPC if banned

### DIFF
--- a/PLRPC/Extensions/PermissionLevelExtensions.cs
+++ b/PLRPC/Extensions/PermissionLevelExtensions.cs
@@ -1,0 +1,20 @@
+﻿using LBPUnion.PLRPC.Types;
+
+namespace LBPUnion.PLRPC.Extensions;
+
+public static class PermissionLevelExtensions
+{
+    public static string ToPrettyString(this PermissionLevel? level)
+    {
+        return level switch
+        {
+            PermissionLevel.Banned => " (Banned)",
+            PermissionLevel.Restricted => " (Restricted)",
+            PermissionLevel.Silenced => " (Silenced)",
+            PermissionLevel.Default => "", // default PermissionLevel doesn't really have a pretty name
+            PermissionLevel.Moderator => " (Moderator)",
+            PermissionLevel.Administrator => " (Administrator)",
+            _ => " (Unknown)",
+        };
+    }
+}

--- a/PLRPC/LighthouseClient.cs
+++ b/PLRPC/LighthouseClient.cs
@@ -40,7 +40,7 @@ public class LighthouseClient
     private async void UpdatePresence()
     {
         User? user = await this.apiRepository.GetUser(this.username);
-        if (user == null)
+        if (user == null || user.PermissionLevel == PermissionLevel.Banned)
         {
             Logger.Warn("Failed to get user from the server.");
             return;
@@ -114,7 +114,7 @@ public class LighthouseClient
                 LargeImageKey = this.serverUrl + "/gameAssets/" + slot.IconHash,
                 LargeImageText = slot.Name,
                 SmallImageKey = this.serverUrl + "/gameAssets/" + user.YayHash,
-                SmallImageText = user.Username,
+                SmallImageText = user.Username + user.PermissionLevel.ToPrettyString(),
             },
             Timestamps = new Timestamps
             {

--- a/PLRPC/PLRPC.csproj
+++ b/PLRPC/PLRPC.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DiscordRichPresence" Version="1.1.3.18"/>
+        <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
     </ItemGroup>
 
 </Project>

--- a/PLRPC/Types/Entities/User.cs
+++ b/PLRPC/Types/Entities/User.cs
@@ -23,4 +23,7 @@ public class User
 
     [JsonPropertyName("lastLogin")]
     public long LastLogin { get; set; }
+
+    [JsonPropertyName("permissionLevel")]
+    public PermissionLevel? PermissionLevel { get; set; }
 }

--- a/PLRPC/Types/PermissionLevel.cs
+++ b/PLRPC/Types/PermissionLevel.cs
@@ -1,0 +1,11 @@
+﻿namespace LBPUnion.PLRPC.Types;
+
+public enum PermissionLevel
+{
+    Banned = -3,
+    Restricted = -2,
+    Silenced = -1,
+    Default = 0,
+    Moderator = 1,
+    Administrator = 2,
+}


### PR DESCRIPTION
PR adds displaying of the user's permission level (i.e. Moderator, Administrator, etc.) in the `SmallImageText` section of the Rich Presence display. Also prevents RPC from being initialized if the user is banned.